### PR TITLE
Made test executable builds optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,35 +24,39 @@ target_include_directories(
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 
 # Test
-find_package(Catch2 REQUIRED)
+option(CTPG_ENABLE_TESTS "Build test binaries" ON)
 
-add_executable(testbin
-    tests/main.cpp
-    tests/regex_tests_1.cpp
-    tests/regex_tests_2.cpp
-    tests/regex_tests_3.cpp
-    tests/simple_cases.cpp
-    tests/simple_grammar.cpp
-    tests/empty_symbols.cpp
-    tests/recurrence.cpp
-    tests/precedence.cpp
-    tests/compile_time.cpp
-    tests/list_helpers.cpp
-    tests/skip_whitespace.cpp
-    tests/typed_terms.cpp
-    tests/source_tracking.cpp
-    tests/error_recovery.cpp
-    tests/buffers.cpp
-)
+if(CTPG_ENABLE_TESTS)
+    find_package(Catch2 REQUIRED)
 
-target_link_libraries(testbin Catch2::Catch2)
-target_include_directories(testbin PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_compile_features(testbin PUBLIC cxx_std_17)
+    add_executable(testbin
+        tests/main.cpp
+        tests/regex_tests_1.cpp
+        tests/regex_tests_2.cpp
+        tests/regex_tests_3.cpp
+        tests/simple_cases.cpp
+        tests/simple_grammar.cpp
+        tests/empty_symbols.cpp
+        tests/recurrence.cpp
+        tests/precedence.cpp
+        tests/compile_time.cpp
+        tests/list_helpers.cpp
+        tests/skip_whitespace.cpp
+        tests/typed_terms.cpp
+        tests/source_tracking.cpp
+        tests/error_recovery.cpp
+        tests/buffers.cpp
+    )
 
-include(CTest)
-include(Catch)
-catch_discover_tests(testbin)
-enable_testing()
+    target_link_libraries(testbin Catch2::Catch2)
+    target_include_directories(testbin PRIVATE ${PROJECT_SOURCE_DIR}/include)
+    target_compile_features(testbin PUBLIC cxx_std_17)
+
+    include(CTest)
+    include(Catch)
+    catch_discover_tests(testbin)
+    enable_testing()
+endif(CTPG_ENABLE_TESTS)
 
 # Install
 install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
Added a `CTPG_ENABLE_TESTS` CMake option that defaults to `ON` to optionally skip tests.