### PR TITLE
C++20 compatibility fix: made operator== and operator!= friend functions

### DIFF
--- a/include/ctpg.hpp
+++ b/include/ctpg.hpp
@@ -124,8 +124,8 @@ namespace stdex
             constexpr it_type* cast() { return static_cast<it_type*>(this); }
             constexpr const it_type* cast() const { return static_cast<const it_type*>(this); }
 
-            constexpr bool operator == (const it_type& other) const { return cast()->ptr == other.ptr; }
-            constexpr bool operator != (const it_type& other) const { return cast()->ptr != other.ptr; }
+            friend constexpr bool operator == (const it_type& a, const it_type& b) { return a.cast()->ptr == b.cast()->ptr; }
+            friend constexpr bool operator != (const it_type& a, const it_type& b) { return a.cast()->ptr != b.cast()->ptr; }
             constexpr it_type operator - (size_type amount) const { return it_type{ cast()->ptr - amount }; }
             constexpr size_type operator - (const it_type& other) const { return size_type(cast()->ptr - other.ptr); }
             constexpr it_type operator + (size_type amount) const { return it_type{ cast()->ptr + amount }; }


### PR DESCRIPTION
Here is an example error message prior to this fix which I got using Clang 13.0.0 with `-std=c++20`:

```
/usr/local/include/ctpg/ctpg.hpp:187:25: error: use of overloaded operator '==' is ambiguous (with operand types 'ctpg::stdex::cvector<unsigned short, 13>::iterator' and 'ctpg::stdex::cvector<unsigned short, 13>::iterator')
            while (!(it == end()))
                     ~~ ^  ~~~~~
```

The way I understand it from explanations by @jfalcou (who suggested this fix to me) is that C++20 generates a `friend operator==` by default which is ambiguous with the one provided by ctpg.

This commit fixes that by providing `operator==` as a friend function rather than a member function, therefore avoiding any ambiguity. `friend operator!=` is also provided after this commit.

Correct me if I'm wrong however.

Regards,
Jules