### PR TITLE
Add construct ftor

### DIFF
--- a/include/ctpg.hpp
+++ b/include/ctpg.hpp
@@ -561,6 +561,27 @@ namespace ftors
         }
     };
 
+    template<typename T, std::size_t FromIdx = 1, typename = std::make_index_sequence<FromIdx - 1>>
+    struct construct
+    {};
+
+    template<
+        typename T,
+        std::size_t FromIdx,
+        std::size_t... Skip
+    >
+    struct construct<
+        T,
+        FromIdx,
+        std::index_sequence<Skip...>>
+    {
+        template<typename Arg, typename... Rest>
+        constexpr auto operator()(ignore<Skip>..., Arg&& arg, Rest&&...) const
+        {
+            return T{std::forward<Arg>(arg)};
+        }
+    };
+
     template<
         std::size_t ContIdx = 1,
         std::size_t ArgIdx = 2,

--- a/readme.md
+++ b/readme.md
@@ -798,7 +798,7 @@ denoting element numbers for the list and the value to append.
 So in case of comma separeted numbers, we can simply use:
 ```c++
 rules(
-    list() >= create<std::vector<int>>{},
+    list(number) >= construct<std::vector<int>, 1>{},
     list(list, ',', number) >= push_back<1, 3>{}  // 1 is the list, 3 is the number
 )
 ```

--- a/readme.md
+++ b/readme.md
@@ -732,6 +732,26 @@ constexpr parser p(
 );
 ```
 
+**construct**
+
+Use to construct an instance of a given type from an argument:
+
+```c++
+
+using namespace ctpg::ftors;
+
+constexpr parser p(
+    something,
+    terms(value),
+    nterms(something),
+    rules(
+        something(value)
+            >= construct<something_type, 1>{}   // 1 is the position of value in the rule, this constructs something_type{value}
+    )
+)
+
+```
+
 **element placeholders**
 
 Use whenever a rule simply passes nth element from the right side:

--- a/tests/list_helpers.cpp
+++ b/tests/list_helpers.cpp
@@ -67,3 +67,24 @@ TEST_CASE("emplace back", "[list helpers]")
     REQUIRE(result.has_value());
     REQUIRE(result.value().size() == 4);
 }
+
+namespace test {
+    constexpr parser p3(
+        c_root,
+        terms('*', ','),
+        nterms(c_root, ct),
+        rules(
+            c_root(ct) >= construct<std::vector<copyable_thing>, 1>{},
+            c_root(c_root, ',', ct) >= push_back<1, 3>{},
+            ct('*') >= create<copyable_thing>{}
+        )
+    );
+}
+
+TEST_CASE("construct", "[list helpers]")
+{
+    auto result = test::p3.parse(cstring_buffer("*,*,*,*"));
+
+    REQUIRE(result.has_value());
+    REQUIRE(result.value().size() == 4);
+}


### PR DESCRIPTION
It turned out the list helpers example for comma separeted numbers did not work, as the first rule does not take the first number and the second rule expects to start with a comma. So I thought it might be a good idea to provide a helper that initializes a container with a given argument.

- added `construct` ftor to do so
- added testcase in `list_helpers.cpp`
- changed documentation