### PR TITLE
Add support for passing external context to parsers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ if (CTPG_ENABLE_TESTS)
         tests/source_tracking.cpp
         tests/error_recovery.cpp
         tests/buffers.cpp
+        tests/contexts.cpp
     )
 
     target_link_libraries(testbin PRIVATE Catch2::Catch2 ctpg::ctpg)

--- a/examples/contexts.cpp
+++ b/examples/contexts.cpp
@@ -1,0 +1,53 @@
+#include <ctpg/ctpg.hpp>
+#include <iostream>
+#include <unordered_map>
+#include <string>
+#include <utility>
+
+using namespace ctpg;
+using namespace ctpg::buffers;
+using namespace ctpg::ftors;
+
+using predefined_variables = std::unordered_map<std::string_view, int>;
+
+constexpr nterm<int> expr("expr");
+
+constexpr char_term o_plus('+', 1, associativity::ltor);
+
+constexpr char variable_pattern[] = "[a-zA-Z_][a-zA-Z_0-9]*";
+constexpr regex_term<variable_pattern> variable("variable");
+
+constexpr parser p(
+    expr,
+    terms(variable, o_plus),
+    nterms(expr),
+    rules(
+        expr(expr, o_plus, expr) >= [](auto left, auto, auto right)
+        {
+            return left + right;
+        },
+        expr(variable) >>= [](const auto& variables, const auto& ident)
+        {
+            return variables.count(ident) == 0 ? 0 : variables.at(ident);
+        }
+    )
+);
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2)
+    {
+        p.write_diag_str(std::cout);
+        return 0;
+    }
+
+    const predefined_variables variables({{"var0", 10}, {"var1", 20}, {"var2", 30}});
+
+    auto res = p.context_parse(variables, parse_options{}.set_verbose(), string_buffer(argv[1]), std::cerr);
+    if (res.has_value())
+    {
+        int rv = res.value();
+        std::cout << "runtime parse: " << rv << std::endl;
+    }
+    return 0;
+}

--- a/tests/contexts.cpp
+++ b/tests/contexts.cpp
@@ -1,0 +1,104 @@
+#include <catch2/catch.hpp>
+#include <ctpg/ctpg.hpp>
+
+using namespace ctpg;
+using namespace ctpg::ftors;
+using namespace ctpg::buffers;
+
+namespace test
+{
+    constexpr nterm<int> root("root");
+
+    constexpr parser p1(
+        root,
+        terms('+', '1'),
+        nterms(root),
+        rules(
+            root('+') >>= [](auto context, auto) { return ++context; },
+            root('1') >= [](auto) { return 1; }
+        )
+    );
+}
+
+TEST_CASE("non-contextual reductors with context", "[contexts]")
+{
+    auto result1 = test::p1.context_parse(5, cstring_buffer("1"));
+    REQUIRE(result1.has_value());
+    REQUIRE(result1.value() == 1);
+
+    auto result2 = test::p1.context_parse(10, cstring_buffer("1"));
+    REQUIRE(result2.has_value());
+    REQUIRE(result2.value() == 1);
+}
+
+TEST_CASE("value context", "[contexts]")
+{
+    auto result1 = test::p1.context_parse(5, cstring_buffer("+"));
+    REQUIRE(result1.has_value());
+    REQUIRE(result1.value() == 6);
+
+    int context = 10;
+    auto result2 = test::p1.context_parse(context, cstring_buffer("+"));
+    REQUIRE(result2.has_value());
+    REQUIRE(result2.value() == 11);
+    REQUIRE(context == 10);
+}
+
+namespace test
+{
+    struct mutable_non_copyable {
+        mutable_non_copyable(int data): data(data) {}
+        mutable_non_copyable(const mutable_non_copyable&) = delete;
+        mutable_non_copyable& operator=(const mutable_non_copyable&) = delete;
+
+        int data = 0;
+    };
+
+    constexpr parser p2(
+        root,
+        terms('$'),
+        nterms(root),
+        rules(
+            root('$') >>= [](const auto &context, auto) { return context.data; }
+        )
+    );
+}
+
+TEST_CASE("const reference context", "[contexts]")
+{
+    const test::mutable_non_copyable context1(5);
+    auto result1 = test::p2.context_parse(context1, cstring_buffer("$"));
+    REQUIRE(result1.has_value());
+    REQUIRE(result1.value() == 5);
+
+    const test::mutable_non_copyable context2(10);
+    auto result2 = test::p2.context_parse(context2, cstring_buffer("$"));
+    REQUIRE(result2.has_value());
+    REQUIRE(result2.value() == 10);
+}
+
+namespace test
+{
+    constexpr parser p3(
+        root,
+        terms('+'),
+        nterms(root),
+        rules(
+            root('+') >>= [](auto &context, auto) { return ++context.data; }
+        )
+    );
+}
+
+TEST_CASE("non-const reference context", "[contexts]")
+{
+    test::mutable_non_copyable context1(5);
+    auto result1 = test::p3.context_parse(context1, cstring_buffer("+"));
+    REQUIRE(result1.has_value());
+    REQUIRE(result1.value() == 6);
+    REQUIRE(context1.data == 6);
+
+    auto result2 = test::p3.context_parse(context1, cstring_buffer("+"));
+    REQUIRE(result2.has_value());
+    REQUIRE(result2.value() == 7);
+    REQUIRE(context1.data == 7);
+}


### PR DESCRIPTION
Hi!

I was trying to use this library to write a simple and fast expression evaluator which would support the use of external variables and functions inside expressions, but I couldn't find any method that would allow me to pass such external context into reducing functors. I mean, the parser itself is constexpr thus it is impossible to capture anything into lambdas and "parse" method doesn't accept any parameters that can be passed to functors.

I think, use of external contexts is a very important feature because the only alternative is creating an AST and then traversing it using a separate algorithm. It requires to perform tons of small memory allocations (one for each AST node) and I'd prefer to avoid it and, at least, use some preallocated memory chunk instead (which is still impossible because I can't tell the parser where this chunk is located).

So, I've tried to add the support for external contexts myself. See the added example and commit description for more info.
It is just a first draft, so, feel free to request any changes.

Also, the known issue is that this implementation is incompatible with list helpers because they accept any arguments including contexts and it leads to hard errors on instantiation of std::is_invocable.

Regards,
Ilya Nozhkin