### PR TITLE
Added buffers::string_view_buffer

### DIFF
--- a/include/ctpg/ctpg.hpp
+++ b/include/ctpg/ctpg.hpp
@@ -778,6 +778,27 @@ namespace buffers
         std::string str;
     };
 
+    class string_view_buffer
+    {
+    public:
+        string_view_buffer(const std::string_view& str):
+            str(str)
+        {}
+
+        auto begin() const { return str.cbegin(); }
+        auto end() const { return str.cend(); }
+
+        using iterator = std::string_view::const_iterator;
+
+        std::string_view get_view(iterator start, iterator end) const
+        {
+            return std::string_view(str.data() + (start - str.begin()), end - start);
+        }
+
+    private:
+        std::string_view str;
+    };
+
     template<typename Buffer>
     using iterator_t = typename Buffer::iterator;
 }

--- a/tests/buffers.cpp
+++ b/tests/buffers.cpp
@@ -34,3 +34,20 @@ TEST_CASE("string buffer", "[buffers]")
     REQUIRE(result.has_value());
     REQUIRE(result.value() == 42);
 }
+
+TEST_CASE("string_view buffer, lvalue", "[buffers]")
+{
+    std::string_view txt(" 0  1  2 ");
+    string_view_buffer buf(txt);
+    auto result = test::p1.parse(buf);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value() == 42);
+}
+
+TEST_CASE("string_view buffer, rvalue", "[buffers]")
+{
+    string_view_buffer buf(std::string_view(" 0  1  2 "));
+    auto result = test::p1.parse(buf);
+    REQUIRE(result.has_value());
+    REQUIRE(result.value() == 42);
+}


### PR DESCRIPTION
I've read the issue #45, but I noticed @hrco159753 never made a pull request;  
I've implemented the same feature, by simply copy-pasting the `string_buffer` class, replacing strings with string_views and adding two test cases.