### PR TITLE
Referenced string_view_buffer in readme.md, fixed a typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1073,7 +1073,9 @@ int main(int argc, char* argv[])
 
 ### Buffers
 
-There are currently two types of buffers available: ```cstring_buffer```, useful for *constexpr* parsing static array like buffer, and ```string_buffer``` for runtime parsing.
+There are currently three types of buffers available:
+- ```cstring_buffer```, useful for *constexpr* parsing static array-like buffers;
+- ```string_buffer``` and ```string_view_buffer``` for runtime parsing.
 
 It is however easy to add custom types of buffers, there are just couple of requirements for the types to be eligible as buffers.
 


### PR DESCRIPTION
The description for `cstring_buffer` used to be "*useful for constexpr parsing static array like buffer*",  
assuming it was a typo, I changed it to "*useful for constexpr parsing static* array-like *buffer****s***" as a side effect of adding the description for `string_view_buffer` - although I'm not sure that was the intended meaning of the original phrasing.