### PR TITLE
Fix: iterator is extended over end of string if no match occurs with `dfa_match`

### DIFF
--- a/include/ctpg/ctpg.hpp
+++ b/include/ctpg/ctpg.hpp
@@ -2940,7 +2940,6 @@ private:
         }
 
         ps.current_term_idx = res.term_idx;
-        ps.current_end_it = ps.current_it + res.len;
 
         if (ps.current_term_idx == uninitialized16)
         {
@@ -2949,6 +2948,7 @@ private:
         }
         else
         {
+            ps.current_end_it = ps.current_it + res.len;
             trace_recognized_term(ps);
         }
 
@@ -3487,7 +3487,13 @@ namespace regex
         constexpr bool match(match_options opts, const Buffer& buf, Stream& s) const
         {
             auto res = dfa_match(sm, opts, source_point{}, buf.begin(), buf.end(), s);
-            auto end = buf.begin() + res.len;
+
+            Buffer::iterator end;
+            if (res.len == uninitialized16)
+                end = buf.end();
+            else
+                end = buf.begin() + res.len;
+
             if (res.term_idx == 0 && end == buf.end())
                 return true;
             else


### PR DESCRIPTION
Hello,

I got an error on Windows 11 and MSVC 19.39 where the parser fails. This happens if the `dfa_match` returns `uninitialized16` and we try to add it to the iterator. Thus here my proposed fix.