### PR TITLE
A few tiny changes for C++23—friendliness

### DIFF
--- a/include/ctpg/ctpg.hpp
+++ b/include/ctpg/ctpg.hpp
@@ -265,7 +265,7 @@ namespace stdex
                 data[i] |= other.data[i];
         }
 
-        constexpr bool operator == (const cbitset<N>& other)
+        constexpr bool operator == (const cbitset<N>& other) const
         {
             for (auto i = 0u; i < underlying_count; ++i)
                 if (data[i] != other.data[i])

--- a/tests/list_helpers.cpp
+++ b/tests/list_helpers.cpp
@@ -38,6 +38,8 @@ namespace test
 {
     struct non_copyable_thing
     {
+        non_copyable_thing() = default;
+
         non_copyable_thing(const non_copyable_thing&) = delete;
         non_copyable_thing& operator = (const non_copyable_thing&) = delete;
 


### PR DESCRIPTION
I recently tried to use `ctpg` for a tiny program of mine, which is written in C++23 - it failed to compile due to an operator overload (see [67be52d](4ccc84956ff8b3474258bc6b74306b53742cfd1a)), and a test failed to compile (see [4ccc849](https://github.com/peter-winter/ctpg/commit/4ccc84956ff8b3474258bc6b74306b53742cfd1a)) after that.

I tried to justify the changes within the commit messages, however I'm not entirely sure why those problems weren't _problems_ before my latest system update (especially the second one I fixed).